### PR TITLE
Support https urls.

### DIFF
--- a/aioinflux/client.py
+++ b/aioinflux/client.py
@@ -43,7 +43,7 @@ class AsyncInfluxDBClient:
     def __init__(self, host: str = 'localhost', port: int = 8086,
                  unix_socket: Optional[str] = None,
                  username: Optional[str] = None, password: Optional[str] = None,
-                 db: str = 'testdb', database: Optional[str] = None,
+                 ssl: bool = False, db: str = 'testdb', database: Optional[str] = None,
                  loop: asyncio.BaseEventLoop = None,
                  log_level: int = 30, mode: str = 'async'):
         """
@@ -62,6 +62,7 @@ class AsyncInfluxDBClient:
         :param unix_socket: Path to the InfluxDB. unix socket.
         :param username: Username to use to connect to InfluxDB.
         :param password: User password.
+        :param ssl: If https should be used.
         :param db: Default database to be used by the client.
         :param database: Default database to be used by the client.
             This field is for argument consistency with the official InfluxDB Python client.
@@ -79,7 +80,7 @@ class AsyncInfluxDBClient:
         self._connector = None if unix_socket is None else aiohttp.UnixConnector(path=unix_socket, loop=self._loop)
         self._auth = aiohttp.BasicAuth(username, password) if username and password else None
         self._session = aiohttp.ClientSession(loop=self._loop, auth=self._auth, connector=self._connector)
-        self._url = f'http://{host}:{port}/{{endpoint}}'
+        self._url = f'{"https" if ssl else "http"}://{host}:{port}/{{endpoint}}'
         self.host = host
         self.port = port
         self.unix_socket = unix_socket


### PR DESCRIPTION
I also think it would be nice to have this helper function part of the library - if acceptable, I will create a pull request:

```
def influx_client_from_url(url: str):
    parsed = urlparse(url)
    is_ssl = parsed.scheme == 'https'
    influxdb_client = AsyncInfluxDBClient(
        host=parsed.hostname,
        port=parsed.port or (443 if is_ssl else 80),
        db=parsed.path[1:],
        username=parsed.username,
        password=parsed.password,
        ssl=is_ssl
    )
    return influxdb_client
```