### PR TITLE
Support aenter/aexit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,13 @@ import pytest
 from aioinflux import AsyncInfluxDBClient
 
 
+@pytest.yield_fixture(scope='module')
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
 @pytest.fixture(scope='module')
 def sync_client():
     with AsyncInfluxDBClient(db='mytestdb', mode='blocking', log_level=5) as client:
@@ -13,9 +20,10 @@ def sync_client():
         client.drop_database(db='mytestdb')
 
 
+@pytest.mark.asyncio
 @pytest.fixture(scope='module')
-def async_client():
-    with AsyncInfluxDBClient(db='mytestdb', mode='async', log_level=5) as client:
+async def async_client():
+    async with AsyncInfluxDBClient(db='mytestdb', mode='async', log_level=5) as client:
         print(client)  # test __repr__
         yield client
 
@@ -26,8 +34,3 @@ def df_client():
         client.create_database(db='mytestdb')
         yield client
         client.drop_database(db='mytestdb')
-
-
-@pytest.fixture
-def event_loop():
-    return asyncio.get_event_loop()


### PR DESCRIPTION
### Defect

The following code would fail to await the `aiohttp.ClientSession.close()` coroutine, or attempt to close the session after the event loop closed.

```python
with AsyncInfluxDBClient(mode='async') as client:
    pass
```

### Desired behavior

```python
def blocking_func():
    with AsyncInfluxDBClient(mode='blocking') as client:
        pass

async def async_func():
    async with AsyncInfluxDBClient(mode='async') as client:
        pass
```

### Changes
* Added `__aenter__`, `__aexit__`, and `close` functions
* Removed `__del__` function. For well-handled cleanup, clients can either explicitly close, or use the context guard. This also avoids unwanted side effects where `__del__` is called after the event loop closes.
* `async_client` fixture is now async, and uses a module scoped event loop

