### PR TITLE
Include the actual error message in exceptions.

### DIFF
--- a/aioinflux/client.py
+++ b/aioinflux/client.py
@@ -138,7 +138,7 @@ class AsyncInfluxDBClient:
             if resp.status == 204:
                 return True
             else:
-                msg = f'Error writing data. Response: {resp.status} | {resp.reason}'
+                msg = f'Error writing data. Response: {resp.status} | {resp.headers.get("X-Influxdb-Error", resp.reason)}'
                 raise InfluxDBError(msg)
 
     @runner


### PR DESCRIPTION
resp.reason just tells me "Bad Request", which is not helpful in tracking down the problem.